### PR TITLE
Fix the projects listing view filters

### DIFF
--- a/app/views/decidim/budgets/projects/index.js.erb
+++ b/app/views/decidim/budgets/projects/index.js.erb
@@ -1,0 +1,2 @@
+var $projects = $('#projects');
+$projects.html('<%= j(render partial: "projects").strip.html_safe %>');


### PR DESCRIPTION
The JS render view is missing which breaks the dynamic filters on the projects page.

Rails is looking for the JS-view from the same folder where the HTML view is present and when it's missing, it renders the HTML view instead.